### PR TITLE
Disable scheduled execution of Smart Automation workflow

### DIFF
--- a/.github/workflows/claude-smart-automation.yml
+++ b/.github/workflows/claude-smart-automation.yml
@@ -1,12 +1,13 @@
 name: Claude Smart Automation
 
 on:
-  schedule:
-    # Smart Automation - 4 times daily schedule
-    - cron: '0 6 * * *'   # 6AM UTC daily
-    - cron: '0 12 * * *'  # 12PM UTC daily
-    - cron: '0 18 * * *'  # 6PM UTC daily
-    - cron: '0 0 * * *'   # 12AM UTC daily
+  # Schedule is disabled - uncomment the lines below to re-enable scheduled execution
+  # schedule:
+  #   # Smart Automation - 4 times daily schedule
+  #   - cron: '0 6 * * *'   # 6AM UTC daily
+  #   - cron: '0 12 * * *'  # 12PM UTC daily
+  #   - cron: '0 18 * * *'  # 6PM UTC daily
+  #   - cron: '0 0 * * *'   # 12AM UTC daily
   workflow_dispatch:
     inputs:
       force_execution:


### PR DESCRIPTION
## Summary
- Disabled all cron schedule triggers for the Smart Automation workflow
- Manual workflow_dispatch trigger remains active for on-demand execution
- Schedule can be re-enabled by uncommenting the schedule section

## Changes
- Commented out all cron expressions in `.github/workflows/claude-smart-automation.yml`
- Added explanatory comment indicating how to re-enable scheduled execution

## Reason
As requested, the automatic scheduled execution of Smart Automation has been stopped to prevent unintended automated runs.

🤖 Generated with [Claude Code](https://claude.ai/code)